### PR TITLE
Partial updates using cropped image

### DIFF
--- a/e_ink_console/screen.py
+++ b/e_ink_console/screen.py
@@ -5,9 +5,11 @@ import subprocess
 import tempfile
 
 from .text_to_image import (
+    crop_image,
     get_contained_text_area,
     get_blank_image,
-    get_terminal_update_image,
+    get_full_terminal_image,
+    get_partial_terminal_image,
     identify_changed_text_area,
 )
 log = logging.getLogger(__name__)
@@ -48,20 +50,23 @@ def write_buffer_to_screen(settings, old_buff, buff, old_cursor, cursor, charact
 
     decoded_buff_list = split(buff.decode(settings.encoding, "replace"), settings.cols * character_encoding_width)
 
-    image = get_terminal_update_image(
-        settings,
-        decoded_buff_list,
-        contained_text_area,
-        cursor,
-    )
+    image = get_full_terminal_image(settings, decoded_buff_list, cursor)
+
+    image = crop_image(settings, image, contained_text_area)
+
+    # For debugging
+    with open("buffer.png", "wb") as fb:
+        image.save(fb)
+
     with tempfile.TemporaryDirectory() as temp_dir:
         with open(os.path.join(temp_dir, "buffer.png"), "wb") as fb:
             image.save(fb)
+
             update_screen(
                 settings.screen_height,
                 settings.screen_width,
                 fb.name,
                 contained_text_area[0] * settings.font_height,
                 contained_text_area[1] * settings.font_width,
-                    it8951_driver,
-                )
+                it8951_driver,
+            )

--- a/e_ink_console/text_to_image.py
+++ b/e_ink_console/text_to_image.py
@@ -10,14 +10,10 @@ WHITE = 255
 log = logging.getLogger(__name__)
 
 def get_full_terminal_image(settings, buffer_list, cursor, spacing=0):
-    image = Image.new(
-        '1',
-        (
-            settings.cols * settings.font_width,
-            settings.rows * settings.font_height,
-        ),
-        WHITE,
-    )
+    width = settings.cols * settings.font_width
+    height = settings.rows * settings.font_height
+    image = Image.new('1', (width, height), WHITE)
+    log.debug(f"Creating image with dimensions {width} x {height}.")
 
     draw = ImageDraw.Draw(image)
     for row in range(settings.rows):
@@ -131,8 +127,8 @@ def crop_image(settings, image, text_area):
         text_area[0] * settings.font_height,
     ]
     lower_right = [
-        (text_area[3] + 0) * settings.font_width,
-        text_area[2] * settings.font_height,
+        min((text_area[3] + 1), settings.cols) * settings.font_width,
+        min((text_area[2] + 1), settings.rows) * settings.font_height,
     ]
-
+    log.debug(f"Cropping image to corners {upper_left} and {lower_right}.")
     return image.crop(upper_left + lower_right)

--- a/tests/test_e2e_output_to_screen.py
+++ b/tests/test_e2e_output_to_screen.py
@@ -13,7 +13,7 @@ from e_ink_console.screen import clear_screen, write_buffer_to_screen
 from e_ink_console.terminal import TerminalSettings, main_loop
 
 from e_ink_console.text_to_image import (
-    get_terminal_update_image,
+    get_partial_terminal_image,
 )
 log = logging.getLogger(__name__)
 
@@ -116,7 +116,7 @@ def test_font_drawing(font_file, name, text_area):
         "          ",
     ]
 
-    image = get_terminal_update_image(
+    image = get_partial_terminal_image(
         settings=settings,
         buffer_list=buffer_list,
         text_area=text_area,
@@ -126,29 +126,3 @@ def test_font_drawing(font_file, name, text_area):
 
     with open(os.path.join(TESTS_DIR, "output", name + ".png"), "wb") as fb:
         image.save(fb)
-
-
-def test_simple_text(font_file):
-    """Play ground to explore spacing between characters and difference in spacing when
-    writing one whole row, or writing a part of it.
-    """
-    settings = TerminalSettings(
-        tty="/dev/tty9999",
-        vcsa="/dev/vcsa9999",
-        rows=4,
-        cols=10,
-        font_file=font_file,
-        font_size=16,
-        screen_width=100,
-        screen_height=40,
-    )
-    image = Image.new('1', (width * settings.font_width, height * settings.font_height), 5)
-    draw = ImageDraw.Draw(image)
-
-    draw.text(
-            (0, 0),
-            to_print,
-            font=settings.font,
-            fill=BLACK,
-            spacing=spacing,
-        )


### PR DESCRIPTION
By always creating the whole image we avoid issues with font kerning. When we do a partial screen update we simply crop the picture to suitable size.

Also fixed a broken test.
